### PR TITLE
chore: setup-node out of beta

### DIFF
--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -12,18 +12,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      
+      - uses: actions/setup-node@v2
         with:
           node-version: '12'
-          check-latest: true
+      
       - run: bash .github/workflows/setup.sh
         env:
           CI: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      
       - run: pnpm run publish-all
         env:
           CI: true
           GITHUB_EVENT_CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
+      
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           # Optional but recommended, defaults to "Apply automatic changes"


### PR DESCRIPTION
Also 

> If check-latest is set to true, the action first checks if the cached version is the latest one. If the locally cached version is not the most up-to-date, a version of Node will then be downloaded. Set check-latest to true it you want the most up-to-date version of Node to always be used.
> 
>     Setting check-latest to true has performance implications as downloading versions of Node is slower than using cached versions
