### PR TITLE
feat: add libquery-engine-napi

### DIFF
--- a/packages/engines/.gitignore
+++ b/packages/engines/.gitignore
@@ -2,3 +2,4 @@ introspection-engine*
 query-engine*
 migration-engine*
 prisma-fmt*
+libquery_engine*

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -6,9 +6,9 @@
   "license": "Apache-2.0",
   "author": "Tim Suchanek <suchanek@prisma.io>",
   "devDependencies": {
-    "@prisma/debug": "^2.9.0",
+    "@prisma/debug": "2.18.0-dev.10",
     "@prisma/engines-version": "workspace:2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223",
-    "@prisma/fetch-engine": "^2.9.0",
+    "@prisma/fetch-engine": "2.18.0-dev.10",
     "@types/node": "^14.11.8",
     "execa": "^4.0.3",
     "typescript": "4.0.3"

--- a/packages/engines/src/download.ts
+++ b/packages/engines/src/download.ts
@@ -27,6 +27,7 @@ async function main() {
     await download({
       binaries: {
         'query-engine': binaryDir,
+        'libquery-engine-napi': binaryDir,
         'migration-engine': binaryDir,
         'introspection-engine': binaryDir,
         'prisma-fmt': binaryDir,

--- a/packages/engines/src/index.ts
+++ b/packages/engines/src/index.ts
@@ -15,6 +15,7 @@ export async function ensureBinariesExist() {
   await download({
     binaries: {
       'query-engine': binaryDir,
+      'libquery-engine-napi': binaryDir,
       'migration-engine': binaryDir,
       'introspection-engine': binaryDir,
       'prisma-fmt': binaryDir,


### PR DESCRIPTION
the precursor of https://github.com/prisma/prisma/pull/5681
- [x] bump fetch engine after [this](https://github.com/prisma/prisma/pull/5708) is merged