### PR TITLE
ci: add workflow dispatch for updates in prisma/prisma

### DIFF
--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -25,6 +25,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - run: pnpm run publish-all
+        id: publish_script
         env:
           CI: true
           GITHUB_EVENT_CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
@@ -38,6 +39,15 @@ jobs:
           commit_user_name: prisma-bot
           commit_user_email: prismabots@gmail.com
           commit_author: prisma-bot <prismabots@gmail.com>
+
+      - name: Workflow dispatch to prisma/prisma for version update
+        if: ${{ steps.publish_script.outputs.new_prisma_version }}
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Update Engines Version
+          repo: prisma/prisma
+          token: ${{ secrets.GH_TOKEN }}
+          inputs: '{ "version": "${{ steps.publish_script.outputs.new_prisma_version }}" }'
 
       - name: Slack Notification on Failure
         if: ${{ failure() }}

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -69,6 +69,8 @@ async function main(dryRun = false) {
   // Print out version for workflow dispatch if npmTag is latest
   if (npmTag === 'latest') {
     console.log(`Printing version for workflow dispatch: ${npmTag}`)
+    // This special log makes new_prisma_version avaliable in github actions
+    // Read: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#using-workflow-commands-to-access-toolkit-functions
     console.log(`::set-output name=new_prisma_version::${npmTag}`)
   }
 }

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -65,6 +65,12 @@ async function main(dryRun = false) {
     `pnpm publish --no-git-checks --tag ${npmTag}`,
     dryRun,
   )
+
+  // Print out version for workflow dispatch if npmTag is latest
+  if (npmTag === 'latest') {
+    console.log(`Printing version for workflow dispatch: ${npmTag}`)
+    console.log(`::set-output name=new_prisma_version::${npmTag}`)
+  }
 }
 
 type ClientInput = {


### PR DESCRIPTION
This adds workflow dispatch to prisma/prisma whenever it releases a new version. 

Follow up to https://github.com/prisma/prisma/pull/7640

The publish script was modified a bit to output the input version whenever it releases a new `latest` tag and not other npm tags. 