### PR TITLE
chore: remove remaining `Napi`

### DIFF
--- a/packages/engines/src/download.ts
+++ b/packages/engines/src/download.ts
@@ -31,7 +31,7 @@ async function main() {
     debug(`using NAPI: ${process.env.PRISMA_FORCE_NAPI === 'true'}`)
     const binaries: BinaryDownloadConfiguration = {
       [process.env.PRISMA_FORCE_NAPI === 'true'
-        ? BinaryType.libqueryEngineNapi
+        ? BinaryType.libqueryEngine
         : BinaryType.queryEngine]: binaryDir,
       [BinaryType.migrationEngine]: binaryDir,
       [BinaryType.introspectionEngine]: binaryDir,

--- a/packages/engines/src/download.ts
+++ b/packages/engines/src/download.ts
@@ -28,7 +28,7 @@ async function main() {
     if (process.env.PRISMA_CLI_BINARY_TARGETS) {
       binaryTargets = process.env.PRISMA_CLI_BINARY_TARGETS.split(',')
     }
-    debug(`using NAPI: ${process.env.PRISMA_FORCE_NAPI === 'true'}`)
+    debug(`using Node API: ${process.env.PRISMA_FORCE_NAPI === 'true'}`)
     const binaries: BinaryDownloadConfiguration = {
       [process.env.PRISMA_FORCE_NAPI === 'true'
         ? BinaryType.libqueryEngine

--- a/packages/engines/src/index.ts
+++ b/packages/engines/src/index.ts
@@ -16,7 +16,7 @@ export async function ensureBinariesExist() {
   debug(`using NAPI: ${process.env.PRISMA_FORCE_NAPI === 'true'}`)
   const binaries = {
     [process.env.PRISMA_FORCE_NAPI === 'true'
-      ? BinaryType.libqueryEngineNapi
+      ? BinaryType.libqueryEngine
       : BinaryType.queryEngine]: binaryDir,
     [BinaryType.migrationEngine]: binaryDir,
     [BinaryType.introspectionEngine]: binaryDir,

--- a/packages/engines/src/index.ts
+++ b/packages/engines/src/index.ts
@@ -13,7 +13,7 @@ export async function ensureBinariesExist() {
   if (process.env.PRISMA_CLI_BINARY_TARGETS) {
     binaryTargets = process.env.PRISMA_CLI_BINARY_TARGETS.split(',')
   }
-  debug(`using NAPI: ${process.env.PRISMA_FORCE_NAPI === 'true'}`)
+  debug(`using Node API: ${process.env.PRISMA_FORCE_NAPI === 'true'}`)
   const binaries = {
     [process.env.PRISMA_FORCE_NAPI === 'true'
       ? BinaryType.libqueryEngine

--- a/packages/fetch-engine/src/download.ts
+++ b/packages/fetch-engine/src/download.ts
@@ -34,7 +34,7 @@ const utimes = promisify(fs.utimes)
 const channel = 'master'
 export enum BinaryType {
   queryEngine = 'query-engine',
-  libqueryEngineNapi = 'libquery-engine',
+  libqueryEngine = 'libquery-engine',
   migrationEngine = 'migration-engine',
   introspectionEngine = 'introspection-engine',
   prismaFmt = 'prisma-fmt',
@@ -60,7 +60,7 @@ export interface DownloadOptions {
 const BINARY_TO_ENV_VAR = {
   [BinaryType.migrationEngine]: 'PRISMA_MIGRATION_ENGINE_BINARY',
   [BinaryType.queryEngine]: 'PRISMA_QUERY_ENGINE_BINARY',
-  [BinaryType.libqueryEngineNapi]: 'PRISMA_QUERY_ENGINE_LIBRARY',
+  [BinaryType.libqueryEngine]: 'PRISMA_QUERY_ENGINE_LIBRARY',
   [BinaryType.introspectionEngine]: 'PRISMA_INTROSPECTION_ENGINE_BINARY',
   [BinaryType.prismaFmt]: 'PRISMA_FMT_BINARY',
 }
@@ -93,7 +93,7 @@ export async function download(options: DownloadOptions): Promise<BinaryPaths> {
         'Warning',
       )} Precompiled binaries are not available for ${platform}. Read more about building your own binaries at https://pris.ly/d/build-binaries`,
     )
-  } else if (BinaryType.libqueryEngineNapi in options.binaries) {
+  } else if (BinaryType.libqueryEngine in options.binaries) {
     await isNodeAPISupported()
   }
 
@@ -118,7 +118,7 @@ export async function download(options: DownloadOptions): Promise<BinaryPaths> {
       opts.binaryTargets.map((binaryTarget) => {
         const fileName = getBinaryName(binaryName, binaryTarget)
         const targetFilePath =
-          binaryName === BinaryType.libqueryEngineNapi
+          binaryName === BinaryType.libqueryEngine
             ? path.join(targetFolder, getNapiName(binaryTarget, 'fs'))
             : path.join(targetFolder, fileName)
         return {
@@ -327,7 +327,7 @@ async function binaryNeedsToBeDownloaded(
   // 3. If same platform, always check --version
   if (
     job.binaryTarget === nativePlatform &&
-    job.binaryName !== BinaryType.libqueryEngineNapi
+    job.binaryName !== BinaryType.libqueryEngine
   ) {
     const works = await checkVersionCommand(binaryPath)
     return !works
@@ -355,7 +355,7 @@ export async function checkVersionCommand(
 }
 
 export function getBinaryName(binaryName: string, platform: Platform): string {
-  if (binaryName === BinaryType.libqueryEngineNapi) {
+  if (binaryName === BinaryType.libqueryEngine) {
     return `${getNapiName(platform, 'url')}`
   }
   const extension = platform === 'windows' ? '.exe' : ''

--- a/packages/fetch-engine/src/download.ts
+++ b/packages/fetch-engine/src/download.ts
@@ -1,6 +1,6 @@
 import Debug from '@prisma/debug'
 import {
-  getNapiName,
+  getNodeAPIName,
   getos,
   getPlatform,
   isNodeAPISupported,
@@ -119,7 +119,7 @@ export async function download(options: DownloadOptions): Promise<BinaryPaths> {
         const fileName = getBinaryName(binaryName, binaryTarget)
         const targetFilePath =
           binaryName === BinaryType.libqueryEngine
-            ? path.join(targetFolder, getNapiName(binaryTarget, 'fs'))
+            ? path.join(targetFolder, getNodeAPIName(binaryTarget, 'fs'))
             : path.join(targetFolder, fileName)
         return {
           binaryName,
@@ -356,7 +356,7 @@ export async function checkVersionCommand(
 
 export function getBinaryName(binaryName: string, platform: Platform): string {
   if (binaryName === BinaryType.libqueryEngine) {
-    return `${getNapiName(platform, 'url')}`
+    return `${getNodeAPIName(platform, 'url')}`
   }
   const extension = platform === 'windows' ? '.exe' : ''
   return `${binaryName}-${platform}${extension}`

--- a/packages/fetch-engine/src/util.ts
+++ b/packages/fetch-engine/src/util.ts
@@ -63,10 +63,10 @@ export function getDownloadUrl(
   const baseUrl =
     process.env.PRISMA_BINARIES_MIRROR || 'https://binaries.prisma.sh'
   const finalExtension =
-    platform === 'windows' && BinaryType.libqueryEngineNapi !== binaryName
+    platform === 'windows' && BinaryType.libqueryEngine !== binaryName
       ? `.exe${extension}`
       : extension
-  if (binaryName === BinaryType.libqueryEngineNapi) {
+  if (binaryName === BinaryType.libqueryEngine) {
     binaryName = getNapiName(platform, 'url')
   }
 

--- a/packages/fetch-engine/src/util.ts
+++ b/packages/fetch-engine/src/util.ts
@@ -1,5 +1,5 @@
 import Debug from '@prisma/debug'
-import { getNapiName, Platform } from '@prisma/get-platform'
+import { getNodeAPIName, Platform } from '@prisma/get-platform'
 import findCacheDir from 'find-cache-dir'
 import fs from 'fs'
 import makeDir from 'make-dir'
@@ -67,7 +67,7 @@ export function getDownloadUrl(
       ? `.exe${extension}`
       : extension
   if (binaryName === BinaryType.libqueryEngine) {
-    binaryName = getNapiName(platform, 'url')
+    binaryName = getNodeAPIName(platform, 'url')
   }
 
   return `${baseUrl}/${channel}/${version}/${platform}/${binaryName}${finalExtension}`

--- a/packages/get-platform/src/getNodeAPIName.ts
+++ b/packages/get-platform/src/getNodeAPIName.ts
@@ -2,15 +2,15 @@
 
 import { Platform } from './platforms'
 
-export const NAPI_QUERY_ENGINE_URL_BASE = 'libquery_engine'
+const NODE_API_QUERY_ENGINE_URL_BASE = 'libquery_engine'
 
 /**
- * Gets Node-API Library name depending on your platform
+ * Gets Node-API Library name depending on the platform
  * @param platform
  * @param type  `fs` gets name used on the file system, `url` gets the name required to download the library from S3
  * @returns
  */
-export function getNapiName(platform: Platform, type: 'url' | 'fs') {
+export function getNodeAPIName(platform: Platform, type: 'url' | 'fs') {
   const isUrl = type === 'url'
   if (platform.includes('windows')) {
     return isUrl ? `query_engine.dll.node` : `query_engine-${platform}.dll.node`
@@ -20,15 +20,15 @@ export function getNapiName(platform: Platform, type: 'url' | 'fs') {
     platform.includes('rhel')
   ) {
     return isUrl
-      ? `${NAPI_QUERY_ENGINE_URL_BASE}.so.node`
-      : `${NAPI_QUERY_ENGINE_URL_BASE}-${platform}.so.node`
+      ? `${NODE_API_QUERY_ENGINE_URL_BASE}.so.node`
+      : `${NODE_API_QUERY_ENGINE_URL_BASE}-${platform}.so.node`
   } else if (platform.includes('darwin')) {
     return isUrl
-      ? `${NAPI_QUERY_ENGINE_URL_BASE}.dylib.node`
-      : `${NAPI_QUERY_ENGINE_URL_BASE}-${platform}.dylib.node`
+      ? `${NODE_API_QUERY_ENGINE_URL_BASE}.dylib.node`
+      : `${NODE_API_QUERY_ENGINE_URL_BASE}-${platform}.dylib.node`
   } else {
     throw new Error(
-      `NAPI is currently not supported on your platform: ${platform}`,
+      `Node API is currently not supported on your platform: ${platform}`,
     )
   }
 }

--- a/packages/get-platform/src/index.ts
+++ b/packages/get-platform/src/index.ts
@@ -1,4 +1,4 @@
-export * from './getNapiName'
+export { getNodeAPIName } from './getNodeAPIName'
 export { getos, getPlatform } from './getPlatform'
 export { isNodeAPISupported } from './isNodeAPISupported'
 export { Platform, platforms } from './platforms'


### PR DESCRIPTION
Renames
- `BinaryType.libqueryEngineNapi` to `BinaryType.libqueryEngine`
- `getNapiName` to `getNodeAPIName`