### PR TITLE
chore: add engines Node.js v12.2 minimum like CLI and Client and use local esbuild

### DIFF
--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -4,8 +4,8 @@ echo $NPM_TOKEN > ~/.npmrc
 
 set -ex
 
-npm i --silent -g pnpm@6.9.1 esbuild@0.8.53 --unsafe-perm
+npm i --silent -g pnpm@6.9.1 --unsafe-perm
 
-pnpm i --no-prefer-frozen-lockfile --ignore-scripts
+pnpm i --no-prefer-frozen-lockfile
 
 pnpm recursive run build

--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -6,6 +6,6 @@ set -ex
 
 npm i --silent -g pnpm@6.9.1 --unsafe-perm
 
-pnpm i --no-prefer-frozen-lockfile
+pnpm i --no-prefer-frozen-lockfile --ignore-scripts
 
 pnpm recursive run build

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "bugs": {
     "url": "https://github.com/prisma/engines-wrapper/issues"
   },
-  "homepage": "https://github.com/prisma/engines-wrapper#readme"
+  "homepage": "https://github.com/prisma/engines-wrapper#readme",
+  "engines": {
+    "node": ">=12.2"
+  }
 }

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -10,6 +10,7 @@
     "@prisma/engines-version": "workspace:2.27.0-28.3fd2cf1fea2a0364dd9c2cb1b25995c695cb8805",
     "@prisma/fetch-engine": "workspace:2.27.0-28.3fd2cf1fea2a0364dd9c2cb1b25995c695cb8805",
     "@types/node": "14.17.4",
+    "esbuild": "0.12.15",
     "execa": "5.1.1",
     "typescript": "4.3.5"
   },

--- a/packages/engines/scripts/build.js
+++ b/packages/engines/scripts/build.js
@@ -1,5 +1,6 @@
 const execa = require('execa')
 const chalk = require('chalk')
+const esbuild = require('esbuild')
 
 async function main() {
   const before = Date.now()
@@ -7,14 +8,22 @@ async function main() {
   // TODO: Combine download.ts and index.ts together to save space
   await Promise.all([
     run('tsc -d', true),
-    run(
-      'esbuild src/download.ts --outfile=download/index.js --bundle --platform=node --target=node10 --minify --sourcemap',
-      false,
-    ),
-    run(
-      'esbuild src/index.ts --outfile=dist/index.js --bundle --platform=node --target=node10',
-      false,
-    ),
+    esbuild.build({
+      sourcemap: true,
+      minify: true,
+      platform: 'node',
+      bundle: true,
+      target: 'node12',
+      outfile: 'download/index.js',
+      entryPoints: ['src/download.ts'],
+    }),
+    esbuild.build({
+      platform: 'node',
+      bundle: true,
+      target: 'node12',
+      outfile: 'dist/index.js',
+      entryPoints: ['src/index.ts'],
+    }),
   ])
 
   const after = Date.now()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,7 @@ importers:
       '@prisma/engines-version': workspace:2.27.0-28.3fd2cf1fea2a0364dd9c2cb1b25995c695cb8805
       '@prisma/fetch-engine': workspace:2.27.0-28.3fd2cf1fea2a0364dd9c2cb1b25995c695cb8805
       '@types/node': 14.17.4
+      esbuild: 0.12.15
       execa: 5.1.1
       typescript: 4.3.5
     devDependencies:
@@ -43,6 +44,7 @@ importers:
       '@prisma/engines-version': link:../engines-version
       '@prisma/fetch-engine': link:../fetch-engine
       '@types/node': 14.17.4
+      esbuild: 0.12.15
       execa: 5.1.1
       typescript: 4.3.5
 
@@ -1725,6 +1727,12 @@ packages:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
       is-arrayish: 0.2.1
+    dev: true
+
+  /esbuild/0.12.15:
+    resolution: {integrity: sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==}
+    hasBin: true
+    requiresBuild: true
     dev: true
 
   /escalade/3.1.1:


### PR DESCRIPTION
It was complaining esbuild command not found when I tried to run dev commands.

Better to copy the local esbuild setup like in prisma/prisma I think.