### PR TITLE
fix: add arm32 to known target

### DIFF
--- a/packages/fetch-engine/src/getLatestTag.ts
+++ b/packages/fetch-engine/src/getLatestTag.ts
@@ -56,6 +56,8 @@ export function getAllUrls(branch: string, commit: string): string[] {
     'freebsd',
     'arm',
     'linux-nixos',
+    'linux-arm32-openssl-1.1.x',
+    'linux-arm32-openssl-1.0.x',
     'openbsd',
     'netbsd',
     'freebsd11',

--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -202,6 +202,11 @@ export async function getPlatform(): Promise<Platform> {
     return `linux-arm-openssl-${libssl}` as Platform
   }
 
+  // 32 bit ARM(eg raspberry pi)
+  if (platform === 'linux' && arch === 'arm') {
+    return `linux-arm32-openssl-${libssl}` as Platform
+  }
+
   if (platform === 'linux' && distro === 'nixos') {
     return 'linux-nixos'
   }

--- a/packages/get-platform/src/platforms.ts
+++ b/packages/get-platform/src/platforms.ts
@@ -8,6 +8,8 @@ export type Platform =
   | 'rhel-openssl-1.1.x'
   | 'linux-arm-openssl-1.1.x'
   | 'linux-arm-openssl-1.0.x'
+  | 'linux-arm32-openssl-1.1.x'
+  | 'linux-arm32-openssl-1.0.x'
   | 'linux-musl'
   | 'linux-nixos'
   | 'windows'
@@ -26,6 +28,8 @@ export const platforms: Array<Platform> = [
   'rhel-openssl-1.1.x',
   'linux-arm-openssl-1.1.x',
   'linux-arm-openssl-1.0.x',
+  'linux-arm32-openssl-1.1.x',
+  'linux-arm32-openssl-1.0.x',
   'linux-musl',
   'linux-nixos',
   'windows',


### PR DESCRIPTION
Fixes: https://github.com/prisma/prisma/issues/8575

We called our 64 bit arm target as `arm` instead of `arm64`. That was causing 32 bit arm targets like raspberry to be unknown resulting us blocking them even if they provide a custom binary. 

This PR adds `linux-arm32-openssl-1.1.x` and `linux-arm32-openssl-1.0.x` in the known target list so that these platforms get unblocked. 