### PR TITLE
feat(PRISMA_ENGINES_MIRROR): Add PRISMA_ENGINES_MIRROR as alias to PRISMA_BINARIES_MIRROR

### DIFF
--- a/packages/fetch-engine/src/util.ts
+++ b/packages/fetch-engine/src/util.ts
@@ -61,7 +61,7 @@ export function getDownloadUrl(
   extension = '.gz',
 ): string {
   const baseUrl =
-    process.env.PRISMA_BINARIES_MIRROR || 'https://binaries.prisma.sh'
+    process.env.PRISMA_BINARIES_MIRROR || process.env.PRISMA_ENGINES_MIRROR || 'https://binaries.prisma.sh'
   const finalExtension =
     platform === 'windows' && BinaryType.libqueryEngine !== binaryName
       ? `.exe${extension}`


### PR DESCRIPTION
Old name is binary specific, so let's just not use it any more and replace documentation to use the more neutral (and fitting) `PRISMA_ENGINES_MIRROR`.

Documentation PR that will introduce this: https://github.com/prisma/docs/pull/2258