### PR TITLE
ci: Add name to improve Buildkite integration

### DIFF
--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -8,7 +8,9 @@ on:
 concurrency: publish-engines
 
 jobs:
-  cli-commands:
+  publish-engines:
+    # Do not change `name`, prisma-engines Buildkite build job depends on this name ending with the commit
+    name: "Publish engines-wrapper packages for prisma-engines branch ${{ github.event.ref }} and commit ${{ github.event.client_payload.commit }}"
     timeout-minutes: 10
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Will enable this: https://github.com/prisma/engineer/issues/44 Useful to have a way to get to a workflow link on Buildkite that can be clicked, instead of having to hunt for the workflow run here by matching the commit.