### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/engines-version/package.json
+++ b/packages/engines-version/package.json
@@ -8,6 +8,11 @@
   "prisma": {
     "enginesVersion": "6a51465e8857a85bad0a12d9261efbceaae55dfc"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/engines-wrapper.git",
+    "directory": "packages/engines-version"
+  },
   "devDependencies": {
     "@types/node": "14.17.27",
     "typescript": "4.4.4"

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -13,6 +13,11 @@
     "execa": "5.1.1",
     "typescript": "4.4.4"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/engines-wrapper.git",
+    "directory": "packages/engines"
+  },
   "scripts": {
     "build": "node scripts/build.js",
     "prepublishOnly": "pnpm run build",


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @prisma/engines
* @prisma/engines-version