### PR TITLE
ci: remove publish auto commit

### DIFF
--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -46,16 +46,6 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           inputs: '{ "version": "${{ steps.publish_script.outputs.new_prisma_version }}" }'
 
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          # Optional but recommended, defaults to "Apply automatic changes"
-          commit_message: engines commit ${{ github.event.client_payload.commit }}
-
-          # Optional commit user and author settings
-          commit_user_name: prisma-bot
-          commit_user_email: prismabots@gmail.com
-          commit_author: prisma-bot <prismabots@gmail.com>
-
       - name: Slack Notification on Failure
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2.2.0


### PR DESCRIPTION
It's actually not needed and causes noise as a failure of the workflow when 2 publish happen "at the same time"
https://github.com/prisma/engines-wrapper/runs/3748154135?check_suite_focus=true

Maybe we should set the version to 0.0.0 in git now

