### PR TITLE
(do not merge) Commit diff from running commands from prismb-fmt-build GH action wor…

### DIFF
--- a/build-prisma-fmt/Cargo.lock
+++ b/build-prisma-fmt/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "datamodel"
 version = "0.1.0"
-source = "git+https://github.com/prisma/prisma-engines#26dcb3782aff45965793e3b77d4237c9e55e15f2"
+source = "git+https://github.com/prisma/prisma-engines#f59d9ce28dc40cc4c4500078bdec423ff03f0a8f"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -172,7 +172,7 @@ dependencies = [
 [[package]]
 name = "datamodel-connector"
 version = "0.1.0"
-source = "git+https://github.com/prisma/prisma-engines#26dcb3782aff45965793e3b77d4237c9e55e15f2"
+source = "git+https://github.com/prisma/prisma-engines#f59d9ce28dc40cc4c4500078bdec423ff03f0a8f"
 dependencies = [
  "dml",
  "enumflags2",
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "dml"
 version = "0.1.0"
-source = "git+https://github.com/prisma/prisma-engines#26dcb3782aff45965793e3b77d4237c9e55e15f2"
+source = "git+https://github.com/prisma/prisma-engines#f59d9ce28dc40cc4c4500078bdec423ff03f0a8f"
 dependencies = [
  "chrono",
  "enumflags2",
@@ -366,7 +366,7 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 [[package]]
 name = "mongodb-datamodel-connector"
 version = "0.1.0"
-source = "git+https://github.com/prisma/prisma-engines#26dcb3782aff45965793e3b77d4237c9e55e15f2"
+source = "git+https://github.com/prisma/prisma-engines#f59d9ce28dc40cc4c4500078bdec423ff03f0a8f"
 dependencies = [
  "datamodel-connector",
  "dml",
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "native-types"
 version = "0.1.0"
-source = "git+https://github.com/prisma/prisma-engines#26dcb3782aff45965793e3b77d4237c9e55e15f2"
+source = "git+https://github.com/prisma/prisma-engines#f59d9ce28dc40cc4c4500078bdec423ff03f0a8f"
 dependencies = [
  "serde",
  "serde_json",
@@ -479,7 +479,7 @@ dependencies = [
 [[package]]
 name = "prisma-fmt"
 version = "0.1.0"
-source = "git+https://github.com/prisma/prisma-engines#26dcb3782aff45965793e3b77d4237c9e55e15f2"
+source = "git+https://github.com/prisma/prisma-engines#f59d9ce28dc40cc4c4500078bdec423ff03f0a8f"
 dependencies = [
  "datamodel",
  "serde",
@@ -498,7 +498,7 @@ dependencies = [
 [[package]]
 name = "prisma-value"
 version = "0.1.0"
-source = "git+https://github.com/prisma/prisma-engines#26dcb3782aff45965793e3b77d4237c9e55e15f2"
+source = "git+https://github.com/prisma/prisma-engines#f59d9ce28dc40cc4c4500078bdec423ff03f0a8f"
 dependencies = [
  "base64",
  "bigdecimal",
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "sql-datamodel-connector"
 version = "0.1.0"
-source = "git+https://github.com/prisma/prisma-engines#26dcb3782aff45965793e3b77d4237c9e55e15f2"
+source = "git+https://github.com/prisma/prisma-engines#f59d9ce28dc40cc4c4500078bdec423ff03f0a8f"
 dependencies = [
  "datamodel-connector",
  "dml",

--- a/build-prisma-fmt/flake.nix
+++ b/build-prisma-fmt/flake.nix
@@ -28,7 +28,7 @@
           checkPhase = "echo 'checkPhase: do nothing'"; # TODO: we should check we have a non-empty .wasm file here
           name = "prisma-fmt-wasm";
           src = ./.;
-          cargoSha256 = "sha256-zu+ELa7aEdLgq4ycImLQvqlG1MCa6GrkVCLZuDYJF08=";
+          cargoSha256 = "sha256-fj0dmGS6/RFkOugH9zpTmlU+jXq6+EYoOGXeA9tr/Aw=";
           installPhase = ''
             echo 'creating out dir...'
             mkdir -p $out/src;

--- a/build-prisma-fmt/package.json
+++ b/build-prisma-fmt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/prisma-fmt-wasm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
…kflow

This shows what a typical diff would look like when a new version of
engines is published and prisma-fmt-wasm is built. We see the engines
versions are updated in cargo.lock, as well as the cargo hash in
flake.nix and the version in package.json