### PR TITLE
build: change esbuild target from Node 10 to 12

### DIFF
--- a/packages/engines/scripts/build.js
+++ b/packages/engines/scripts/build.js
@@ -8,11 +8,11 @@ async function main() {
   await Promise.all([
     run('tsc -d', true),
     run(
-      'esbuild src/download.ts --outfile=download/index.js --bundle --platform=node --target=node10 --minify --sourcemap',
+      'esbuild src/download.ts --outfile=download/index.js --bundle --platform=node --target=node12 --minify --sourcemap',
       false,
     ),
     run(
-      'esbuild src/index.ts --outfile=dist/index.js --bundle --platform=node --target=node10',
+      'esbuild src/index.ts --outfile=dist/index.js --bundle --platform=node --target=node12',
       false,
     ),
   ])


### PR DESCRIPTION
Something we should have done a some time ago I guess when we deprecated Node.js 10 support for Prisma packages.