### PR TITLE
feat: Add workflow dispatch to prisma/prisma-fmt-wasm

### DIFF
--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -38,7 +38,8 @@ jobs:
           GITHUB_EVENT_CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
 
       - name: Workflow dispatch to prisma/prisma for version update
-        if: ${{ steps.publish_script.outputs.new_prisma_version }}
+        # Only automatically trigger update for `latest`!
+        if: steps.publish_script.outputs.npm_dist_tag == 'latest' 
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: Update Engines Version
@@ -47,13 +48,12 @@ jobs:
           inputs: '{ "version": "${{ steps.publish_script.outputs.new_prisma_version }}" }'
 
       - name: Workflow dispatch to prisma/prisma-fmt-wasm for version update
-        if: ${{ steps.publish_script.outputs.new_prisma_version }}
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: new-engines-version
           repo: prisma/prisma-fmt-wasm
           token: ${{ secrets.BOT_TOKEN }}
-          inputs: '{ "enginesWrapperVersion": "${{ steps.publish_script.outputs.new_prisma_version }}", "engineHash": "${{ github.event.client_payload.commit }}", "npmDistTag": "${{ steps.publish_script.outputs.npm_dist_tag }}" }'
+          inputs: '{ "engineHash": "${{ github.event.client_payload.commit }}", "enginesWrapperVersion": "${{ steps.publish_script.outputs.new_prisma_version }}", "npmDistTag": "${{ steps.publish_script.outputs.npm_dist_tag }}" }'
           
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -46,6 +46,15 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           inputs: '{ "version": "${{ steps.publish_script.outputs.new_prisma_version }}" }'
 
+      - name: Workflow dispatch to prisma/prisma-fmt-wasm for version update
+        if: ${{ steps.publish_script.outputs.new_prisma_version }}
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: new-engines-version
+          repo: prisma/prisma-fmt-wasm
+          token: ${{ secrets.BOT_TOKEN }}
+          inputs: '{ "enginesWrapperVersion": "${{ steps.publish_script.outputs.new_prisma_version }}", "engineHash": "${{ github.event.client_payload.commit }}" }'
+          
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           # Optional but recommended, defaults to "Apply automatic changes"

--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Workflow dispatch to prisma/prisma-fmt-wasm for version update
         uses: benc-uk/workflow-dispatch@v1
         with:
-          workflow: new-engines-version
+          workflow: Build and publish @prisma/prisma-fmt-wasm
           repo: prisma/prisma-fmt-wasm
           token: ${{ secrets.BOT_TOKEN }}
           inputs: '{ "engineHash": "${{ github.event.client_payload.commit }}", "enginesWrapperVersion": "${{ steps.publish_script.outputs.new_prisma_version }}", "npmDistTag": "${{ steps.publish_script.outputs.npm_dist_tag }}" }'

--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -53,7 +53,7 @@ jobs:
           workflow: new-engines-version
           repo: prisma/prisma-fmt-wasm
           token: ${{ secrets.BOT_TOKEN }}
-          inputs: '{ "enginesWrapperVersion": "${{ steps.publish_script.outputs.new_prisma_version }}", "engineHash": "${{ github.event.client_payload.commit }}" }'
+          inputs: '{ "enginesWrapperVersion": "${{ steps.publish_script.outputs.new_prisma_version }}", "engineHash": "${{ github.event.client_payload.commit }}", "npmDistTag": "${{ steps.publish_script.outputs.npm_dist_tag }}" }'
           
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -55,6 +55,12 @@ async function main(dryRun = false) {
   console.log(`${chalk.bold('New version')}   ${newVersion}`)
   console.log(`${chalk.bold('Npm Dist Tag')}  ${npmDistTag}\n`)
 
+  console.log(`Printing values for workflow dispatch: ${newVersion}, ${npmDistTag}`)
+  // This special log makes values avaliable in Github Actions
+  // Read: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#using-workflow-commands-to-access-toolkit-functions
+  console.log(`::set-output name=new_prisma_version::${newVersion}`)
+  console.log(`::set-output name=npm_dist_Tag::${npmDistTag}`)
+  
   // Publish Order
   // [engines-version, get-platform], fetch-engine, engines
 
@@ -119,14 +125,6 @@ async function main(dryRun = false) {
     `pnpm publish --no-git-checks --tag ${npmDistTag}`,
     dryRun,
   )
-
-  // Print out version for workflow dispatch if npmTag is latest
-  if (npmDistTag === 'latest') {
-    console.log(`Printing version for workflow dispatch: ${newVersion}`)
-    // This special log makes new_prisma_version avaliable in github actions
-    // Read: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#using-workflow-commands-to-access-toolkit-functions
-    console.log(`::set-output name=new_prisma_version::${newVersion}`)
-  }
 }
 
 /** Apply call back function to content of file and write it back */

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -59,7 +59,7 @@ async function main(dryRun = false) {
   // This special log makes values avaliable in Github Actions
   // Read: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#using-workflow-commands-to-access-toolkit-functions
   console.log(`::set-output name=new_prisma_version::${newVersion}`)
-  console.log(`::set-output name=npm_dist_Tag::${npmDistTag}`)
+  console.log(`::set-output name=npm_dist_tag::${npmDistTag}`)
   
   // Publish Order
   // [engines-version, get-platform], fetch-engine, engines


### PR DESCRIPTION
Includes both version string of just released packages but also the original engine commit hash as input.