### PR TITLE
chore: rename master to main for engines repo branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   </h2>
 </div>
   
-This repository contains the code for packages `@prisma/engines`, `@prisma/engines-version`, `@prisma/fetch-engine` and `@prisma/get-platform`. They are wrapping the [Prisma Rust Engines](https://github.com/prisma/prisma-engines) in npm packages to be used by the [Prisma CLI, the Client](https://github.com/prisma/prisma), and other tooling. 
+This repository contains the code for packages `@prisma/engines`, `@prisma/engines-version`, `@prisma/fetch-engine` and `@prisma/get-platform`. They are wrapping the [Prisma Rust Engines](https://github.com/prisma/prisma-engines) in npm packages to be used by the [Prisma CLI, the Client](https://github.com/prisma/prisma), and other tooling.
 
-[The automated publish pipeline](https://github.com/prisma/engines-wrapper/actions/workflows/publish-engines.yml) is triggered during the publish process of [`prisma-engines`](https://github.com/prisma/prisma-engines) by the [engineer CLI](https://github.com/prisma/engineer/blob/master/src/trigger/mod.rs).
+[The automated publish pipeline](https://github.com/prisma/engines-wrapper/actions/workflows/publish-engines.yml) is triggered during the publish process of [`prisma-engines`](https://github.com/prisma/prisma-engines) by the [engineer CLI](https://github.com/prisma/engineer/blob/main/src/trigger/mod.rs).
 This `engines-wrapper` GitHub Actions workflow informs other repositories (e.g. [`prisma/prisma`](https://github.com/prisma/prisma) and [`prisma/prisma-fmt-wasm`](https://github.com/prisma/prisma-fmt-wasm)) of these published npm packages.

--- a/packages/fetch-engine/src/getLatestTag.ts
+++ b/packages/fetch-engine/src/getLatestTag.ts
@@ -196,14 +196,17 @@ function isPatchBranch(version: string): boolean {
 }
 
 async function getCommits(branch: string): Promise<string[] | object> {
+  // A simple cache in front of GitHub API that was implemented to avoid a rate-limit error in the past
+  // See https://dash.cloudflare.com/c72786e48b88e7492830a60584c2ac13/workers/services/view/github-cache/production
   const url = `https://github-cache.prisma.workers.dev/repos/prisma/prisma-engines/commits?sha=${branch}`
   const result = await fetch(url, {
     agent: getProxyAgent(url) as any,
-    headers: {
-      Authorization: process.env.GITHUB_TOKEN
-        ? `token ${process.env.GITHUB_TOKEN}`
-        : undefined,
-    },
+// Headers are not used by the worker
+//     headers: {
+//       Authorization: process.env.GITHUB_TOKEN
+//         ? `token ${process.env.GITHUB_TOKEN}`
+//         : undefined,
+//     },
   } as any).then((res) => res.json())
 
   if (!Array.isArray(result)) {

--- a/packages/fetch-engine/src/getLatestTag.ts
+++ b/packages/fetch-engine/src/getLatestTag.ts
@@ -9,11 +9,11 @@ import { getDownloadUrl } from './util'
 export async function getLatestTag(): Promise<any> {
   let branch = await getBranch()
   if (
-    branch !== 'master' &&
+    branch !== 'main' &&
     !isPatchBranch(branch) &&
     !branch.startsWith('integration/')
   ) {
-    branch = 'master'
+    branch = 'main'
   }
 
   // remove the "integration/" part
@@ -22,17 +22,17 @@ export async function getLatestTag(): Promise<any> {
 
   // first try to get the branch as it is
   // if it doesn't have an equivalent in the engines repo
-  // default back to master
+  // default back to main
   let commits = await getCommits(branch)
   if (
     (!commits || !Array.isArray(commits)) &&
-    branch !== 'master' &&
+    branch !== 'main' &&
     !isPatchBranch(branch)
   ) {
     console.log(
-      `Overwriting branch "${branch}" with "master" as it's not a branch we have binaries for`,
+      `Overwriting branch "${branch}" with "main" as it's not a branch we have binaries for`,
     )
-    branch = 'master'
+    branch = 'main'
     commits = await getCommits(branch)
   }
 

--- a/scripts/dispatch.sh
+++ b/scripts/dispatch.sh
@@ -2,5 +2,5 @@
 
 curl -H "Authorization: token $GH_TOKEN" \
 --request POST \
---data '{"event_type": "publish-engines", "client_payload": {"branch": "master", "commit": "0c2898954d761d1c92f304ff1b7917c601c2e3d8"}}' \
+--data '{"event_type": "publish-engines", "client_payload": {"branch": "main", "commit": "0c2898954d761d1c92f304ff1b7917c601c2e3d8"}}' \
 https://api.github.com/repos/prisma/engines-wrapper/dispatches


### PR DESCRIPTION
Since https://github.com/prisma/prisma-engines default branch got renamed from master to main the `test / fetch-engine` test is failing because it's trying to get info fro the `master` branch.

This is blocking the test which means all merges are blocked at the moment.

Example of failure
https://github.com/prisma/engines-wrapper/runs/4711780986?check_suite_focus=true
```
FAIL src/__tests__/download.test.ts (65.203 s)
  ● Console

    console.error
      {
        message: 'Not Found',
        documentation_url: 'docs.github.com/rest/reference/repos#list-commits'
      }

      38 |
      39 |   if (!Array.isArray(commits)) {
    > 40 |     console.error(commits)
         |             ^
      41 |     throw new Error(
      42 |       `Could not fetch commits from github: ${JSON.stringify(
      43 |         commits,

      at getLatestTag (src/getLatestTag.ts:40:13)
          at runMicrotasks (<anonymous>)
      at download (src/download.ts:140:20)
      at Object.<anonymous> (src/__tests__/download.test.ts:195:15)
```

Note that we still have 2 occurrences of `const channel = 'master'` but this is different. It's the name of the cache folder.
We could also change it to be consistent but that would mean that the `master` directory would not be deleted and binaries would stay there "forever."
See https://sourcegraph.com/search?q=context:global+repo:github.com/prisma/engines-wrapper+master&patternType=literal

