### PR TITLE
Allow setting platform using an env var

### DIFF
--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -172,6 +172,9 @@ async function gracefulExec(cmd: string): Promise<string | undefined> {
 }
 
 export async function getPlatform(): Promise<Platform> {
+  if (process.env.PRISMA_PLATFORM)
+    return process.env.PRISMA_PLATFORM as Platform;
+
   const { platform, libssl, distro, arch } = await getos()
 
   // Apple Silicon (M1)


### PR DESCRIPTION
This allows users to run prisma on platforms which are yet to be officially supported, for e.g. OpenSSL 3 on linux. This can provide a workaround for https://github.com/prisma/prisma/issues/11677