### PR TITLE
Revert "chore(deps): update dependency @types/node to v16.11.65"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "devDependencies": {
     "@sindresorhus/slugify": "1.1.2",
-    "@types/node": "16.11.65",
+    "@types/node": "16.11.64",
     "@types/node-fetch": "2.6.2",
     "arg": "5.0.2",
     "chalk": "4.1.2",

--- a/packages/engines-version/package.json
+++ b/packages/engines-version/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/engines-version"
   },
   "devDependencies": {
-    "@types/node": "16.11.65",
+    "@types/node": "16.11.64",
     "typescript": "4.8.4"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ importers:
   .:
     specifiers:
       '@sindresorhus/slugify': 1.1.2
-      '@types/node': 16.11.65
+      '@types/node': 16.11.64
       '@types/node-fetch': 2.6.2
       arg: 5.0.2
       chalk: 4.1.2
@@ -18,7 +18,7 @@ importers:
       typescript: 4.8.4
     devDependencies:
       '@sindresorhus/slugify': 1.1.2
-      '@types/node': 16.11.65
+      '@types/node': 16.11.64
       '@types/node-fetch': 2.6.2
       arg: 5.0.2
       chalk: 4.1.2
@@ -27,15 +27,15 @@ importers:
       is-ci: 3.0.1
       node-fetch: 2.6.7
       prettier: 2.7.1
-      ts-node: 10.9.1_32pi7snzzbarjvfhwlvtgaxef4
+      ts-node: 10.9.1_k2jc2lb6qrtdc3lulqxjwnbwoi
       typescript: 4.8.4
 
   packages/engines-version:
     specifiers:
-      '@types/node': 16.11.65
+      '@types/node': 16.11.64
       typescript: 4.8.4
     devDependencies:
-      '@types/node': 16.11.65
+      '@types/node': 16.11.64
       typescript: 4.8.4
 
 packages:
@@ -98,12 +98,12 @@ packages:
   /@types/node-fetch/2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 16.11.65
+      '@types/node': 16.11.64
       form-data: 3.0.0
     dev: true
 
-  /@types/node/16.11.65:
-    resolution: {integrity: sha512-Vfz7wGMOr4jbQGiQHVJm8VjeQwM9Ya7mHe9LtQ264/Epf5n1KiZShOFqk++nBzw6a/ubgYdB9Od7P+MH/LjoWw==}
+  /@types/node/16.11.64:
+    resolution: {integrity: sha512-z5hPTlVFzNwtJ2LNozTpJcD1Cu44c4LNuzaq1mwxmiHWQh2ULdR6Vjwo1UGldzRpzL0yUEdZddnfqGW2G70z6Q==}
     dev: true
 
   /acorn-walk/8.1.1:
@@ -358,7 +358,7 @@ packages:
     resolution: {integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=}
     dev: true
 
-  /ts-node/10.9.1_32pi7snzzbarjvfhwlvtgaxef4:
+  /ts-node/10.9.1_k2jc2lb6qrtdc3lulqxjwnbwoi:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -377,7 +377,7 @@ packages:
       '@tsconfig/node12': 1.0.7
       '@tsconfig/node14': 1.0.0
       '@tsconfig/node16': 1.0.2
-      '@types/node': 16.11.65
+      '@types/node': 16.11.64
       acorn: 8.7.1
       acorn-walk: 8.1.1
       arg: 4.1.3


### PR DESCRIPTION
Reverts prisma/engines-wrapper#428

Publish action is failing with
```
 > @prisma/engines-version@4.5.0-26.810aaacead8837bb6f5b6a051d719353d2c360fb build /home/runner/work/engines-wrapper/engines-wrapper/packages/engines-version
> tsc -d

Error: ../../node_modules/.pnpm/@types+node@16.11.65/node_modules/@types/node/ts4.8/stream.d.ts(842,39): error TS2304: Cannot find name 'Blob'.
undefined
```