### PR TITLE
feat(publish): use provenance for npm publishing

### DIFF
--- a/.github/workflows/dry-publish.yml
+++ b/.github/workflows/dry-publish.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
 
       - run: bash .github/workflows/setup.sh
 
@@ -37,3 +37,5 @@ jobs:
         id: publish_script
         env:
           GITHUB_EVENT_CLIENT_PAYLOAD: '{"branch": "main", "commit": "e2942655e5370b20e0b3942f4717c2a302b0b620"}'
+          # https://docs.npmjs.com/generating-provenance-statements
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -14,6 +14,10 @@ jobs:
     name: 'Publish engines-wrapper packages for prisma-engines branch ${{ github.event.client_payload.branch }} and commit ${{ github.event.client_payload.commit }}'
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    permissions:
+      # required for publishing to npm with --provenance
+      # see https://docs.npmjs.com/generating-provenance-statements
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
 
       - run: bash .github/workflows/setup.sh
         env:
@@ -37,6 +41,8 @@ jobs:
         env:
           CI: true
           GITHUB_EVENT_CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
+          # https://docs.npmjs.com/generating-provenance-statements
+          NPM_CONFIG_PROVENANCE: true
 
       - name: Workflow dispatch to prisma/prisma-engines for @prisma/prisma-schema-wasm publish to npm
         uses: benc-uk/workflow-dispatch@v1

--- a/scripts/dispatch.sh
+++ b/scripts/dispatch.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
+GH_TOKEN="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"
+
 curl -H "Authorization: token $GH_TOKEN" \
 --request POST \
---data '{"event_type": "publish-engines", "client_payload": {"branch": "main", "commit": "0c2898954d761d1c92f304ff1b7917c601c2e3d8"}}' \
+--data '{"event_type": "publish-engines", "client_payload": {"branch": "main", "commit": "43aefb4a29db88d246ea74e047e05571b65aa86f"}}' \
 https://api.github.com/repos/prisma/engines-wrapper/dispatches

--- a/scripts/dispatch.sh
+++ b/scripts/dispatch.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-GH_TOKEN="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"
-
 curl -H "Authorization: token $GH_TOKEN" \
 --request POST \
---data '{"event_type": "publish-engines", "client_payload": {"branch": "main", "commit": "43aefb4a29db88d246ea74e047e05571b65aa86f"}}' \
+--data '{"event_type": "publish-engines", "client_payload": {"branch": "main", "commit": "0c2898954d761d1c92f304ff1b7917c601c2e3d8"}}' \
 https://api.github.com/repos/prisma/engines-wrapper/dispatches


### PR DESCRIPTION
See https://prisma-company.slack.com/archives/C1FPU5FPT/p1698675822988359

I switched to Node.js 20, like in prisma/prisma for publishing (we need to have a more recent version of npm for provenances)