### PR TITLE
chore(publish-engines.yml): fix gh token to contents: write

### DIFF
--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -18,6 +18,9 @@ jobs:
       # required for publishing to npm with --provenance
       # see https://docs.npmjs.com/generating-provenance-statements
       id-token: write
+      # Give the default GITHUB_TOKEN write permission to commit and push 
+      # For stefanzweifel/git-auto-commit-action below
+      contents: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
It was not obvious it was needed when I made https://github.com/prisma/engines-wrapper/pull/476

This fixes the issue we have in logs
```
remote: Permission to prisma/engines-wrapper.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/prisma/engines-wrapper/': The requested URL returned error: 403
Error: Invalid status code: 128
    at ChildProcess.<anonymous> (/home/runner/work/_actions/stefanzweifel/git-auto-commit-action/v5/index.js:17:19)
```

See https://prisma-company.slack.com/archives/C04MT6GARR6/p1699887185658869