### PR TITLE
fix: debounce workflow

### DIFF
--- a/.github/workflows/dry-publish.yml
+++ b/.github/workflows/dry-publish.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       # Debounce so we won't run competing jobs if we merge multiple PRs in prisma-engines in quick succesion
       - name: Debounce 1 minute
-        uses: zachary95/github-actions-debounce
+        uses: zachary95/github-actions-debounce@v0.1.0
         with:
           wait: 60
 

--- a/.github/workflows/dry-publish.yml
+++ b/.github/workflows/dry-publish.yml
@@ -25,6 +25,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Debounce so we won't run competing jobs if we merge multiple PRs in prisma-engines in quick succesion
+      - name: Debounce 1 minute
+        uses: zachary95/github-actions-debounce
+        with:
+          wait: 60
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -20,6 +20,12 @@ jobs:
       id-token: write
 
     steps:
+      # Debounce so we won't run competing jobs if we merge multiple PRs in prisma-engines in quick succesion
+      - name: Debounce 1 minute
+        uses: zachary95/github-actions-debounce
+        with:
+          wait: 60
+
       - uses: actions/checkout@v4
         with: 
           token: ${{ secrets.PRISMA_BOT_TOKEN }}

--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Debounce so we won't run competing jobs if we merge multiple PRs in prisma-engines in quick succesion
       - name: Debounce 1 minute
-        uses: zachary95/github-actions-debounce
+        uses: zachary95/github-actions-debounce@v0.1.0
         with:
           wait: 60
 


### PR DESCRIPTION
Debounce workflow runs to avoid running competing jobs when merging PRs in prisma-engines in quick succession.

Uses https://github.com/marketplace/actions/workflow-run-debounce