### PR TITLE
chore: add build and publish trigger for `@prisma/schema-engine-wasm`

### DIFF
--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -76,6 +76,14 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           inputs: '{ "enginesHash": "${{ github.event.client_payload.commit }}", "packageVersion": "${{ steps.publish_script.outputs.new_prisma_version }}", "npmDistTag": "${{ steps.publish_script.outputs.npm_dist_tag }}" }'
 
+      - name: Workflow dispatch to prisma/prisma-engines for @prisma/schema-engine-wasm publish to npm
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Build and publish @prisma/schema-engine-wasm
+          repo: prisma/prisma-engines
+          token: ${{ secrets.BOT_TOKEN }}
+          inputs: '{ "enginesHash": "${{ github.event.client_payload.commit }}", "packageVersion": "${{ steps.publish_script.outputs.new_prisma_version }}", "npmDistTag": "${{ steps.publish_script.outputs.npm_dist_tag }}" }'
+
       - name: Workflow dispatch to prisma/prisma for version update
         uses: benc-uk/workflow-dispatch@v1
         with:


### PR DESCRIPTION
This PR closes [ORM-725](https://linear.app/prisma-company/issue/ORM-725/build-and-publish-prismaschema-engine-wasm).