### PR TITLE
ci: dispatch the prisma/prisma engines bump against the v7 branch

### DIFF
--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -82,6 +82,10 @@ jobs:
         with:
           workflow: Update Engines Version
           repo: prisma/prisma
+          # Prisma 7 lives on the `v7` branch of prisma/prisma, while its `main` branch hosts a
+          # different codebase. Without an explicit ref the dispatch resolves against the default
+          # branch, which does not have this workflow, and the bump would silently stop happening.
+          ref: v7
           token: ${{ secrets.BOT_TOKEN_ENGINES_WRAPPER_DISPATCH_CI }}
           inputs: '{ "version": "${{ steps.publish_script.outputs.new_prisma_version }}", "npmDistTag": "${{ steps.publish_script.outputs.npm_dist_tag }}" }'
 


### PR DESCRIPTION
## Problem

The last step of `publish-engines.yml` dispatches the `Update Engines Version` workflow to prisma/prisma. It passes no `ref`, so GitHub resolves the workflow name against prisma/prisma's **default branch**.

Prisma 7's code is moving from prisma/prisma's `main` to a new `v7` branch, and prisma/prisma-next's tree becomes the new `main`. That tree has no `Update Engines Version` workflow, so once the swap happens this dispatch would fail to resolve and engine version bumps into the Prisma 7 line would stop — silently, since a failed dispatch here is easy to miss among the four dispatch steps.

The `ref` also determines which branch prisma/prisma's `update-engines-version.yml` checks out, and therefore which branch the resulting bump PR is based on. Even without the resolution failure, we would want `v7` here rather than whatever the default branch happens to be.

## Change

Adds `ref: v7` to the prisma/prisma dispatch step, with a comment explaining why.

The three dispatches to prisma/prisma-engines are deliberately left alone: that repo's default branch is unaffected and still correct for the wasm publish workflows.

## Safe to merge now

`v7` already exists on prisma/prisma, currently pointing at the same commit as `main`, and already contains `.github/workflows/update-engines-version.yml`. So this resolves correctly both before and after the branch swap — no need to coordinate the merge with it.

## Companion PRs

- prisma/prisma — branch triggers on the relevant workflows
- prisma/prisma-engines — `PRISMA_BRANCH` default

## Not changed here

`scripts/publish.ts` is untouched. Its `prismaEnginesBranchToNpmDistTag()` mapping (prisma-engines `main` -> dist-tag `latest`) is still correct: prisma-engines keeps building 7.x engines from its own `main`, and `prisma@latest` remains a 7.x version. Likewise `dry-publish.yml` is untouched — the `main` in its fake payload is a prisma-engines branch name, not a prisma/prisma one.

Worth flagging for the future: `publish.ts` derives its version prefix from the npm `prisma@latest` dist-tag, and maps prisma-engines `main` to `latest`. Both assumptions will need revisiting if a future major ever takes over the `prisma` package's `latest` tag.
