### PR TITLE
ci: address the prisma/prisma engines bump workflow by filename

### DIFF
--- a/.github/workflows/publish-engines.yml
+++ b/.github/workflows/publish-engines.yml
@@ -80,11 +80,14 @@ jobs:
       - name: Workflow dispatch to prisma/prisma for version update
         uses: benc-uk/workflow-dispatch@v1
         with:
-          workflow: Update Engines Version
+          # Addressed by filename rather than display name: the filename is what
+          # GitHub keys a workflow's registry entry on, so it survives edits to
+          # the `name:` field.
+          workflow: v7-update-engines-version.yml
           repo: prisma/prisma
           # Prisma 7 lives on the `v7` branch of prisma/prisma, while its `main` branch hosts a
-          # different codebase. Without an explicit ref the dispatch resolves against the default
-          # branch, which does not have this workflow, and the bump would silently stop happening.
+          # different codebase. `main` carries only a registration stub at this path, which fails
+          # with an explanatory message; `ref` is what selects the workflow that does the work.
           ref: v7
           token: ${{ secrets.BOT_TOKEN_ENGINES_WRAPPER_DISPATCH_CI }}
           inputs: '{ "version": "${{ steps.publish_script.outputs.new_prisma_version }}", "npmDistTag": "${{ steps.publish_script.outputs.npm_dist_tag }}" }'


### PR DESCRIPTION
## Summary

GitHub keys a workflow's registry entry on its **file path**, not on its display name. prisma/prisma is prefixing its 7.x dispatch-driven workflows with `v7-` (prisma/prisma#29823) and registering those paths with stubs on its default branch (prisma/prisma#29822), so this dispatch follows the new filename.

Addressing the workflow by filename rather than by `Update Engines Version` also makes the dispatch immune to future edits of the `name:` field — the display name is a label, the path is the identifier.

The `ref: v7` already present is unchanged and still required: `main` carries only a registration stub at that path, and `ref` is what selects the workflow that does the work. The surrounding comment is updated to describe that arrangement.

## Ordering

1. prisma/prisma#29822 — stubs register the `v7-*` paths on the default branch
2. prisma/prisma#29823 — `v7` renames its workflows to those paths
3. **this PR**

Between (2) and (3) engine-bump dispatches will fail, because `v7` will have the new filename while this repository still asks for the old display name. The window should be kept short; a bump missed in it can be re-run by dispatching `v7-update-engines-version.yml` against `v7` by hand.

## Testing performed

- YAML parsed and job structure checked.
- The change is a single `with:` value plus comments; it cannot be exercised until the prisma/prisma side lands. The first engine bump after merge is the real test — worth watching rather than assuming.
